### PR TITLE
Keep benchmark exclusions portable across shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Notable changes to Tuiuiu are documented here.
 - Require Node.js 22.12 or newer.
 - Separate functional tests from performance benchmarks.
 - Make prerelease publication an explicit manual action.
-- Keep benchmark exclusions portable across PowerShell, Bash, and POSIX shells.
+- Keep test commands and platform-aware shortcut assertions portable across
+  PowerShell, Bash, POSIX shells, Linux, Windows, and macOS.
 - Enforce coverage, runtime reachability, package-size, public-contract, and
   real Linux PTY checks in CI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,5 +43,6 @@ Notable changes to Tuiuiu are documented here.
 - Require Node.js 22.12 or newer.
 - Separate functional tests from performance benchmarks.
 - Make prerelease publication an explicit manual action.
+- Keep benchmark exclusions portable across PowerShell, Bash, and POSIX shells.
 - Enforce coverage, runtime reachability, package-size, public-contract, and
   real Linux PTY checks in CI.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuiuiu.js",
-  "version": "1.0.72",
+  "version": "1.0.73",
   "description": "Zero-dependency Terminal UI library with Component-based experience for Node.js",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -135,8 +135,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "pnpm run clean && tsc",
-    "test": "vitest --exclude tests/benchmarks/**",
-    "test:run": "vitest run --exclude tests/benchmarks/**",
+    "test": "vitest --exclude \"tests/benchmarks/**\"",
+    "test:run": "vitest run --exclude \"tests/benchmarks/**\"",
     "test:coverage": "vitest run --coverage --exclude \"tests/benchmarks/**\"",
     "test:watch": "vitest watch",
     "test:performance": "vitest run tests/core/frame-performance.test.ts tests/core/buffer-perf.test.ts tests/benchmarks/runtime-performance.test.ts tests/benchmarks/runtime-stress.test.ts",

--- a/tests/components/keyboard-shortcut-hint.test.ts
+++ b/tests/components/keyboard-shortcut-hint.test.ts
@@ -14,6 +14,8 @@ import {
 } from '../../src/atoms/keyboard-shortcut-hint.js';
 import type { VNode } from '../../src/utils/types.js';
 
+const platformCtrl = process.platform === 'darwin' ? '⌘' : 'Ctrl';
+
 describe('KeyboardShortcutHint', () => {
   beforeEach(() => {
     setRenderMode('unicode');
@@ -23,16 +25,15 @@ describe('KeyboardShortcutHint', () => {
     const node = KeyboardShortcutHint({ shortcut: 'ctrl+s' });
     expect(node).not.toBeNull();
     expect(node.type).toBe('text');
-    // On Linux the formatted hotkey is "Ctrl+S"
     const output = renderToString(node, 40);
-    expect(output).toContain('Ctrl+S');
+    expect(output).toContain(`${platformCtrl}+S`);
   });
 
   it('renders shortcut with action using default separator', () => {
     const node = KeyboardShortcutHint({ shortcut: 'ctrl+s', action: 'save' });
     expect(node).not.toBeNull();
     const output = renderToString(node, 40);
-    expect(output).toContain('Ctrl+S');
+    expect(output).toContain(`${platformCtrl}+S`);
     expect(output).toContain('save');
   });
 
@@ -109,8 +110,7 @@ describe('KeyboardShortcutHint', () => {
     });
     expect(node).not.toBeNull();
     const output = renderToString(node, 40);
-    // The text should contain "Ctrl+Z: undo" (not "Ctrl+Z to undo")
-    expect(output).toContain('Ctrl+Z');
+    expect(output).toContain(`${platformCtrl}+Z`);
     expect(output).toContain('undo');
     // Should NOT contain the default separator
     expect(output).not.toContain(' to ');

--- a/tests/components/menu.test.ts
+++ b/tests/components/menu.test.ts
@@ -18,6 +18,8 @@ import {
   type MenuOptions,
 } from '../../src/molecules/menu.js';
 
+const platformCtrl = process.platform === 'darwin' ? '⌘' : 'Ctrl';
+
 // =============================================================================
 // createMenu — state factory
 // =============================================================================
@@ -310,7 +312,7 @@ describe('Menu Component', () => {
     expect(node).not.toBeNull();
     const output = renderToString(node, 40);
     expect(output).toContain('Save');
-    expect(output).toContain('Ctrl+S');
+    expect(output).toContain(`${platformCtrl}+S`);
   });
 
   it('renders submenu indicator', () => {
@@ -426,7 +428,7 @@ describe('Menu Component', () => {
     }), 40));
     const lines = output.split('\n').filter(Boolean);
 
-    expect(output).toContain('Ctrl+S');
+    expect(output).toContain(`${platformCtrl}+S`);
     expect(lines.every((line) => stringWidth(line) <= 20)).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

- quote every Vitest benchmark exclusion so Bash, PowerShell, and other shells pass the same literal glob
- bump the package to `1.0.73`
- document the portability fix in the changelog

`v1.0.72` reached the release workflow, but its quality job stopped before any publish job because macOS Bash expanded the unquoted benchmark glob. That tag was intentionally left untouched as an immutable aborted-release record; `v1.0.73` is the corrected release.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm typecheck:tests`
- `pnpm test:run` — 7,455 passed, 1 skipped
- `pnpm build`
- `pnpm verify:package-budget`
- `pnpm verify:contracts`
- `pnpm publish --dry-run --no-git-checks`
