### PR TITLE
fix: stabilize responsive layouts and add OpenCode showcase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Type-check tests
         run: pnpm typecheck:tests
 
+      - name: Type-check examples
+        run: pnpm typecheck:examples
+
       - name: Check runtime import cycles
         run: pnpm check:cycles
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Build terminal apps that feel native. These examples recreate familiar CLI tools
 pnpm tsx examples/app-htop.ts   # Process monitor with live updates
 pnpm tsx examples/app-mtr.ts    # Network route tracer
 pnpm tsx examples/app-ping.ts   # Network latency monitor
+pnpm example opencode-lab       # OpenCode-inspired responsive agent shell
 pnpm example tuiuiu-invaders    # Literal ASCII Space Invaders
 pnpm example tuiuiu-meteor      # Asteroids-style meteor splitter
 pnpm example tuiuiu-sideblaster # Horizontal shoot'em up

--- a/docs/resources/examples.md
+++ b/docs/resources/examples.md
@@ -49,6 +49,7 @@ These are good for inspiration, not as a first implementation reference.
 | `advanced-charts` | Advanced | Advanced data visualization composition |
 | `interactive-charts` | Advanced | Keyboard navigation and chart selection |
 | `terminal-image-pipeline` | Medium | Protocol selection, fallback, and terminal-image resize |
+| `opencode-lab` | Advanced | OpenCode-inspired agent shell with responsive home, session, command overlay, and sidebar |
 | `tuiuiu-invaders` | Advanced | Literal Space Invaders clone |
 | [`tuiuiu-meteor`](/resources/examples/tuiuiu-meteor.md) | Advanced | Asteroids-style meteor splitter |
 | [`tuiuiu-sideblaster`](/resources/examples/tuiuiu-sideblaster.md) | Advanced | Horizontal shoot'em up showcase |

--- a/examples/manifest.ts
+++ b/examples/manifest.ts
@@ -265,6 +265,14 @@ export const examplesManifest: ExampleManifestEntry[] = [
     difficulty: 'advanced',
   },
   {
+    name: 'opencode-lab',
+    file: 'opencode-lab.ts',
+    description: 'OpenCode-inspired responsive agent shell with a centered composer, session timeline, command overlay, and sidebar.',
+    category: 'showcase',
+    difficulty: 'advanced',
+    validate: true,
+  },
+  {
     name: 'performance-demo',
     file: 'performance-demo.ts',
     description: 'Rendering and state-update performance instrumentation.',

--- a/examples/opencode-lab.ts
+++ b/examples/opencode-lab.ts
@@ -8,6 +8,9 @@
  * Run with: pnpm example opencode-lab
  */
 
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import {
   BigText,
   Box,
@@ -27,7 +30,7 @@ import {
   type VNode,
 } from '../src/index.js';
 
-const colors = {
+export const colors = {
   background: '#050505',
   surface: '#191919',
   surfaceRaised: '#202020',
@@ -45,13 +48,13 @@ const MODELS = ['Big Pickle', 'GPT-5.6', 'Claude Sonnet'] as const;
 const AGENTS = ['Build', 'Plan'] as const;
 const version = await getVersion();
 
-interface ConversationMessage {
+export interface ConversationMessage {
   id: number;
   role: 'user' | 'assistant';
   content: string;
 }
 
-interface ScreenFrameProps {
+export interface ScreenFrameProps {
   width: number;
   height: number;
   composer: VNode;
@@ -141,7 +144,7 @@ function Footer(props: { width: number; showVersion?: boolean }): VNode {
   );
 }
 
-function HomeScreen(props: ScreenFrameProps): VNode {
+export function HomeScreen(props: ScreenFrameProps): VNode {
   const cardWidth = Math.max(20, Math.min(68, props.width - 6));
 
   return Box(
@@ -428,7 +431,7 @@ function CommandOverlay(props: { width: number; height: number }): VNode {
   );
 }
 
-function SessionScreen(props: ScreenFrameProps): VNode {
+export function SessionScreen(props: ScreenFrameProps): VNode {
   if (props.commandOpen) {
     return CommandOverlay({ width: props.width, height: props.height });
   }
@@ -512,7 +515,7 @@ function SessionScreen(props: ScreenFrameProps): VNode {
   );
 }
 
-function OpenCodeLab(): VNode {
+export function OpenCodeLab(): VNode {
   const { exit } = useApp();
   const { columns, rows } = useTerminalSize();
   const [screen, setScreen] = useState<'home' | 'session'>('home');
@@ -703,11 +706,28 @@ function OpenCodeLab(): VNode {
       });
 }
 
-const app = render(() => OpenCodeLab(), {
-  screenMode: 'alternate',
-  autoTabNavigation: false,
-  exitOnCtrlC: false,
-  maxFps: 30,
-});
+export async function runOpenCodeLab(): Promise<void> {
+  const app = render(() => OpenCodeLab(), {
+    screenMode: 'alternate',
+    autoTabNavigation: false,
+    exitOnCtrlC: false,
+    maxFps: 30,
+  });
 
-await app.waitUntilExit();
+  await app.waitUntilExit();
+}
+
+function isDirectExecution(): boolean {
+  const entryPath = process.argv[1];
+  if (!entryPath) return false;
+
+  const resolvedEntry = path.resolve(entryPath);
+  const modulePath = fileURLToPath(import.meta.url);
+  return process.platform === 'win32'
+    ? resolvedEntry.toLowerCase() === modulePath.toLowerCase()
+    : resolvedEntry === modulePath;
+}
+
+if (isDirectExecution()) {
+  await runOpenCodeLab();
+}

--- a/examples/opencode-lab.ts
+++ b/examples/opencode-lab.ts
@@ -1,0 +1,713 @@
+#!/usr/bin/env node
+/**
+ * OpenCode-inspired assistant shell built entirely with tuiuiu.js.
+ *
+ * There is no JSX, CSS, browser renderer, or copied OpenCode implementation.
+ * The example uses OpenCode only as a visual and interaction reference.
+ *
+ * Run with: pnpm example opencode-lab
+ */
+
+import {
+  BigText,
+  Box,
+  ShimmerText,
+  Spacer,
+  Text,
+  TextInput,
+  getVersion,
+  render,
+  truncateText,
+  useApp,
+  useInput,
+  useState,
+  useTerminalSize,
+  useTextInputState,
+  useTimeout,
+  type VNode,
+} from '../src/index.js';
+
+const colors = {
+  background: '#050505',
+  surface: '#191919',
+  surfaceRaised: '#202020',
+  sidebar: '#111111',
+  border: '#25262d',
+  text: '#e8e8ea',
+  muted: '#596489',
+  subtle: '#343b59',
+  accent: '#29b6f6',
+  warning: '#f2a343',
+  positive: '#70c994',
+} as const;
+
+const MODELS = ['Big Pickle', 'GPT-5.6', 'Claude Sonnet'] as const;
+const AGENTS = ['Build', 'Plan'] as const;
+const version = await getVersion();
+
+interface ConversationMessage {
+  id: number;
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface ScreenFrameProps {
+  width: number;
+  height: number;
+  composer: VNode;
+  agent: string;
+  model: string;
+  commandOpen?: boolean;
+  sidebarVisible?: boolean;
+  sessionTitle?: string;
+  messages?: ConversationMessage[];
+  thinking?: boolean;
+}
+
+let nextMessageId = 1;
+
+function AgentLine(props: { agent: string; model: string }): VNode {
+  return Box(
+    { flexDirection: 'row' },
+    Text({ color: colors.accent, bold: true }, props.agent),
+    Text({ color: colors.text }, ' · '),
+    Text({ color: colors.text, bold: true }, props.model),
+    Text({ color: colors.muted }, '  OpenCode Zen'),
+  );
+}
+
+function Composer(props: {
+  input: VNode;
+  width: number;
+  agent: string;
+  model: string;
+}): VNode {
+  return Box(
+    {
+      flexDirection: 'column',
+      width: props.width,
+      backgroundColor: colors.surface,
+      borderStyle: 'single',
+      borderTop: false,
+      borderRight: false,
+      borderBottom: false,
+      borderColor: colors.accent,
+      paddingLeft: 1,
+      paddingRight: 1,
+    },
+    props.input,
+    AgentLine({ agent: props.agent, model: props.model }),
+  );
+}
+
+function ShortcutBar(props: { compact?: boolean }): VNode {
+  return Box(
+    { flexDirection: 'row', width: 'fill' },
+    Text({ color: colors.text, bold: true }, 'tab'),
+    Text({ color: colors.muted }, ' agents'),
+    Text({ color: colors.text, bold: true }, '   ctrl+p'),
+    Text({ color: colors.muted }, ' commands'),
+    props.compact ? Text({}, '') : Spacer(),
+    props.compact
+      ? Text({}, '')
+      : Box(
+          { flexDirection: 'row' },
+          Text({ color: colors.text, bold: true }, 'ctrl+b'),
+          Text({ color: colors.muted }, ' sidebar'),
+        ),
+  );
+}
+
+function Footer(props: { width: number; showVersion?: boolean }): VNode {
+  const cwd = process.cwd().replaceAll('\\', '/');
+  const versionLabel = `tuiuiu.js ${version}`;
+  const pathWidth = Math.max(8, props.width - versionLabel.length - 4);
+
+  return Box(
+    {
+      flexDirection: 'row',
+      width: props.width,
+      paddingLeft: 1,
+      paddingRight: 1,
+    },
+    Text(
+      { color: colors.subtle },
+      truncateText(cwd, pathWidth, { position: 'start' }),
+    ),
+    Spacer(),
+    props.showVersion === false
+      ? Text({}, '')
+      : Text({ color: colors.subtle }, versionLabel),
+  );
+}
+
+function HomeScreen(props: ScreenFrameProps): VNode {
+  const cardWidth = Math.max(20, Math.min(68, props.width - 6));
+
+  return Box(
+    {
+      flexDirection: 'column',
+      width: props.width,
+      height: props.height,
+      backgroundColor: colors.background,
+    },
+    Box(
+      {
+        height: Math.max(1, props.height - 1),
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: props.width,
+      },
+      Box(
+        {
+          flexDirection: 'column',
+          width: cardWidth,
+        },
+        Box(
+          {
+            flexDirection: 'column',
+            alignItems: 'center',
+            marginBottom: 2,
+          },
+          BigText({
+            text: 'opencode',
+            font: 'small',
+            gradient: [
+              colors.subtle,
+              colors.subtle,
+              colors.muted,
+              colors.text,
+              colors.text,
+            ],
+            letterSpacing: 1,
+          }),
+        ),
+        Composer({
+          input: props.composer,
+          width: cardWidth,
+          agent: props.agent,
+          model: props.model,
+        }),
+        Box(
+          { width: cardWidth, paddingTop: 0 },
+          ShortcutBar({ compact: true }),
+        ),
+        Box(
+          {
+            flexDirection: 'row',
+            justifyContent: 'center',
+            width: cardWidth,
+            marginTop: 2,
+          },
+          Text({ color: colors.warning }, '● '),
+          Text({ color: colors.warning, bold: true }, 'Tip'),
+          Text({ color: colors.muted }, '  Type '),
+          Text({ color: colors.text }, '/help'),
+          Text({ color: colors.muted }, ' to explore this tuiuiu.js example'),
+        ),
+      ),
+    ),
+    Footer({ width: props.width }),
+  );
+}
+
+function MessageTimeline(props: {
+  width: number;
+  messages: ConversationMessage[];
+  thinking: boolean;
+  agent: string;
+  model: string;
+}): VNode {
+  if (props.messages.length === 0) {
+    return Box(
+      { flexDirection: 'column', paddingX: 2, paddingTop: 1 },
+      Text(
+        { color: colors.muted },
+        'Start a session by writing in the composer below.',
+      ),
+    );
+  }
+
+  const nodes: VNode[] = [];
+
+  for (const message of props.messages) {
+    if (message.role === 'user') {
+      nodes.push(
+        Box(
+          {
+            width: props.width,
+            backgroundColor: colors.sidebar,
+            borderStyle: 'single',
+            borderTop: false,
+            borderRight: false,
+            borderBottom: false,
+            borderColor: colors.accent,
+            paddingX: 2,
+            paddingY: 1,
+          },
+          Text({ color: colors.text }, message.content),
+        ),
+      );
+      continue;
+    }
+
+    nodes.push(
+      Box(
+        {
+          flexDirection: 'column',
+          width: props.width,
+          paddingX: 2,
+          paddingTop: 1,
+        },
+        Text({ color: colors.text }, message.content),
+      ),
+    );
+  }
+
+  if (props.thinking) {
+    nodes.push(
+      Box(
+        {
+          flexDirection: 'column',
+          paddingLeft: 2,
+          paddingTop: 1,
+        },
+        Box(
+          { flexDirection: 'row' },
+          Text({ color: colors.warning }, '⠿ '),
+          ShimmerText({
+            text: 'Thinking',
+            color: colors.warning,
+            shimmerColor: colors.text,
+          }),
+        ),
+        Box(
+          { flexDirection: 'row', marginTop: 1 },
+          Text({ color: colors.accent }, '▣  '),
+          AgentLine({ agent: props.agent, model: props.model }),
+        ),
+      ),
+    );
+  }
+
+  return Box(
+    {
+      flexDirection: 'column',
+      width: props.width,
+      overflow: 'hidden',
+    },
+    ...nodes,
+  );
+}
+
+function GettingStartedCard(): VNode {
+  return Box(
+    {
+      flexDirection: 'column',
+      backgroundColor: colors.surface,
+      paddingX: 2,
+      paddingY: 1,
+      width: 'fill',
+    },
+    Box(
+      { flexDirection: 'row' },
+      Text({ color: colors.text, bold: true }, '◇ Getting started'),
+      Spacer(),
+      Text({ color: colors.muted }, '×'),
+    ),
+    Text({ color: colors.muted }, ''),
+    Text({ color: colors.muted }, 'OpenCode includes free models'),
+    Text({ color: colors.muted }, 'so you can start immediately.'),
+    Text({ color: colors.muted }, ''),
+    Text({ color: colors.muted }, 'This example validates layout,'),
+    Text({ color: colors.muted }, 'input, async updates and resize.'),
+    Text({ color: colors.muted }, ''),
+    Box(
+      { flexDirection: 'row' },
+      Text({ color: colors.text }, 'Try a command'),
+      Spacer(),
+      Text({ color: colors.muted }, '/help'),
+    ),
+  );
+}
+
+function SessionSidebar(props: {
+  width: number;
+  height: number;
+  title: string;
+  messages: ConversationMessage[];
+}): VNode {
+  const tokenEstimate = Math.ceil(
+    props.messages.reduce(
+      (total, message) => total + message.content.length,
+      0,
+    ) / 4,
+  );
+  const cwd = truncateText(
+    process.cwd().replaceAll('\\', '/'),
+    Math.max(8, props.width - 4),
+    { position: 'start' },
+  );
+
+  return Box(
+    {
+      flexDirection: 'column',
+      width: props.width,
+      height: props.height,
+      backgroundColor: colors.sidebar,
+      paddingX: 2,
+      paddingY: 1,
+    },
+    Text({ color: colors.text, bold: true }, props.title || 'New session'),
+    Text({ color: colors.text }, ''),
+    Text({ color: colors.text, bold: true }, 'Context'),
+    Text({ color: colors.muted }, `${tokenEstimate.toLocaleString()} tokens`),
+    Text({ color: colors.muted }, '0% used'),
+    Text({ color: colors.muted }, '$0.00 spent'),
+    Text({ color: colors.text }, ''),
+    Text({ color: colors.text, bold: true }, 'LSP'),
+    Text({ color: colors.muted }, 'LSPs are disabled'),
+    Spacer(),
+    GettingStartedCard(),
+    Box(
+      { flexDirection: 'column', marginTop: 1 },
+      Text({ color: colors.text, bold: true }, cwd),
+      Text({ color: colors.muted }, '● tuiuiu/opencode lab'),
+      Text({ color: colors.subtle }, `  tuiuiu.js ${version}`),
+    ),
+  );
+}
+
+function CommandOverlay(props: { width: number; height: number }): VNode {
+  const overlayWidth = Math.max(20, Math.min(70, props.width - 8));
+  const commands = [
+    ['New session', 'ctrl+n'],
+    ['Toggle sidebar', 'ctrl+b'],
+    ['Switch agent', 'tab'],
+    ['Return home', '/home'],
+    ['Clear transcript', '/clear'],
+  ] as const;
+
+  return Box(
+    {
+      width: props.width,
+      height: props.height,
+      backgroundColor: colors.background,
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    Box(
+      {
+        flexDirection: 'column',
+        width: overlayWidth,
+        backgroundColor: colors.surface,
+        borderStyle: 'single',
+        borderColor: colors.border,
+        paddingX: 2,
+        paddingY: 1,
+      },
+      Text({ color: colors.text, bold: true }, 'Commands'),
+      Text({ color: colors.muted }, 'Type Ctrl+P or Escape to close'),
+      Text({}, ''),
+      ...commands.map(([label, shortcut], index) =>
+        Box(
+          {
+            flexDirection: 'row',
+            backgroundColor:
+              index === 0 ? colors.surfaceRaised : colors.surface,
+            paddingX: 1,
+          },
+          Text({ color: index === 0 ? colors.accent : colors.text }, label),
+          Spacer(),
+          Text({ color: colors.muted }, shortcut),
+        ),
+      ),
+    ),
+  );
+}
+
+function SessionScreen(props: ScreenFrameProps): VNode {
+  if (props.commandOpen) {
+    return CommandOverlay({ width: props.width, height: props.height });
+  }
+
+  const showSidebar = (props.sidebarVisible ?? true) && props.width >= 105;
+  const sidebarWidth = showSidebar ? 38 : 0;
+  const mainWidth = props.width - sidebarWidth;
+
+  const main = Box(
+    {
+      flexDirection: 'column',
+      width: mainWidth,
+      height: props.height,
+      backgroundColor: colors.background,
+    },
+    Box(
+      {
+        flexGrow: 1,
+        width: mainWidth,
+        overflow: 'hidden',
+      },
+      MessageTimeline({
+        width: mainWidth,
+        messages: props.messages ?? [],
+        thinking: props.thinking ?? false,
+        agent: props.agent,
+        model: props.model,
+      }),
+    ),
+    Composer({
+      input: props.composer,
+      width: mainWidth - 2,
+      agent: props.agent,
+      model: props.model,
+    }),
+    Box(
+      {
+        flexDirection: 'row',
+        width: mainWidth,
+        height: 1,
+        paddingX: 2,
+      },
+      Text(
+        { color: props.thinking ? colors.warning : colors.positive },
+        '▮▮▮',
+      ),
+      Text(
+        { color: colors.text, bold: true },
+        props.thinking ? '   esc' : '   ready',
+      ),
+      Text(
+        { color: colors.muted },
+        props.thinking ? ' interrupt' : '',
+      ),
+      Spacer(),
+      Text({ color: colors.text, bold: true }, 'tab'),
+      Text({ color: colors.muted }, ' agents   '),
+      Text({ color: colors.text, bold: true }, 'ctrl+p'),
+      Text({ color: colors.muted }, ' commands   '),
+      Text({ color: colors.text, bold: true }, 'ctrl+b'),
+      Text({ color: colors.muted }, ' sidebar'),
+    ),
+  );
+
+  return Box(
+    {
+      flexDirection: 'row',
+      width: props.width,
+      height: props.height,
+      backgroundColor: colors.background,
+    },
+    main,
+    showSidebar
+      ? SessionSidebar({
+          width: sidebarWidth,
+          height: props.height,
+          title: props.sessionTitle ?? 'New session',
+          messages: props.messages ?? [],
+        })
+      : Text({}, ''),
+  );
+}
+
+function OpenCodeLab(): VNode {
+  const { exit } = useApp();
+  const { columns, rows } = useTerminalSize();
+  const [screen, setScreen] = useState<'home' | 'session'>('home');
+  const [messages, setMessages] = useState<ConversationMessage[]>([]);
+  const [thinking, setThinking] = useState(false);
+  const [sessionTitle, setSessionTitle] = useState('New session');
+  const [agentIndex, setAgentIndex] = useState(0);
+  const [modelIndex] = useState(0);
+  const [sidebarVisible, setSidebarVisible] = useState(true);
+  const [commandOpen, setCommandOpen] = useState(false);
+  const input = useTextInputState({
+    multiline: true,
+    autoGrow: true,
+    maxLines: 5,
+    wordWrap: true,
+    cursorStyle: 'bar',
+  });
+
+  const agent = AGENTS[agentIndex()] ?? AGENTS[0];
+  const model = MODELS[modelIndex()] ?? MODELS[0];
+  const isHome = screen() === 'home';
+  const showSidebar = sidebarVisible() && columns >= 105;
+  const sidebarWidth = showSidebar ? 38 : 0;
+  const mainWidth = columns - sidebarWidth;
+  const homeWidth = Math.max(20, Math.min(68, columns - 6));
+  const inputWidth = Math.max(
+    20,
+    (isHome ? homeWidth : mainWidth - 2) - 4,
+  );
+
+  function runCommand(value: string): boolean {
+    const command = value.trim().toLowerCase();
+    if (command === '/help') {
+      setCommandOpen(true);
+      return true;
+    }
+    if (command === '/clear') {
+      setMessages([]);
+      setThinking(false);
+      return true;
+    }
+    if (command === '/home') {
+      setScreen('home');
+      setMessages([]);
+      setThinking(false);
+      setSessionTitle('New session');
+      return true;
+    }
+    if (command === '/sidebar') {
+      setSidebarVisible((visible) => !visible);
+      return true;
+    }
+    return false;
+  }
+
+  function submit(value: string): void {
+    const prompt = value.trim();
+    if (!prompt || thinking()) return;
+    if (runCommand(prompt)) {
+      input.clear();
+      return;
+    }
+
+    if (screen() === 'home') {
+      setScreen('session');
+      setSessionTitle(
+        prompt.length > 42 ? `${prompt.slice(0, 39)}...` : prompt,
+      );
+    }
+
+    setMessages((current) => [
+      ...current,
+      { id: nextMessageId++, role: 'user', content: prompt },
+    ]);
+    setThinking(true);
+    input.clear();
+  }
+
+  input.updateOptions({
+    placeholder: isHome
+      ? 'Ask anything... "Fix broken tests"'
+      : 'Ask a follow-up...',
+    multiline: true,
+    autoGrow: true,
+    maxLines: 5,
+    wordWrap: true,
+    cursorStyle: 'bar',
+    isActive: () => !commandOpen(),
+    onSubmit: submit,
+    onCancel: () => {
+      if (commandOpen()) {
+        setCommandOpen(false);
+      } else if (thinking()) {
+        setThinking(false);
+      }
+    },
+  });
+
+  useTimeout(
+    () => {
+      setMessages((current) => [
+        ...current,
+        {
+          id: nextMessageId++,
+          role: 'assistant',
+          content:
+            'This OpenCode-inspired shell is running entirely on tuiuiu.js. '
+            + 'Try resizing the terminal, Ctrl+P, Ctrl+B, Tab, /clear or /home.',
+        },
+      ]);
+      setThinking(false);
+    },
+    1_800,
+    { enabled: thinking() },
+  );
+
+  useInput(
+    (char, key) => {
+      if (key.ctrl && char === 'c') {
+        exit();
+        return true;
+      }
+      if ((key.ctrl && char === 'p') || (commandOpen() && key.escape)) {
+        setCommandOpen((open) => !open);
+        return true;
+      }
+      if (commandOpen()) return true;
+      if (key.ctrl && char === 'b') {
+        setSidebarVisible((visible) => !visible);
+        return true;
+      }
+      if (key.ctrl && char === 'n') {
+        setScreen('home');
+        setMessages([]);
+        setThinking(false);
+        setSessionTitle('New session');
+        input.clear();
+        return true;
+      }
+      if (key.tab && !key.shift) {
+        setAgentIndex((index) => (index + 1) % AGENTS.length);
+        return true;
+      }
+      if (key.escape && thinking()) {
+        setThinking(false);
+        return true;
+      }
+      return false;
+    },
+    { priority: 'modal', stopPropagation: true },
+  );
+
+  const composer = TextInput({
+    state: input,
+    placeholder: isHome
+      ? 'Ask anything... "Fix broken tests"'
+      : 'Ask a follow-up...',
+    borderStyle: 'none',
+    prompt: '',
+    focusedBorderColor: colors.accent,
+    foreground: colors.text,
+    fullWidth: true,
+    multiline: true,
+    autoGrow: true,
+    maxLines: 5,
+    wordWrap: true,
+    cursorStyle: 'bar',
+    width: inputWidth,
+  });
+
+  const frame = {
+    width: Math.max(40, columns),
+    height: Math.max(16, rows),
+    composer,
+    agent,
+    model,
+  };
+
+  return isHome
+    ? HomeScreen(frame)
+    : SessionScreen({
+        ...frame,
+        messages: messages(),
+        thinking: thinking(),
+        sessionTitle: sessionTitle(),
+        commandOpen: commandOpen(),
+        sidebarVisible: sidebarVisible(),
+      });
+}
+
+const app = render(() => OpenCodeLab(), {
+  screenMode: 'alternate',
+  autoTabNavigation: false,
+  exitOnCtrlC: false,
+  maxFps: 30,
+});
+
+await app.waitUntilExit();

--- a/scripts/examples.ts
+++ b/scripts/examples.ts
@@ -7,6 +7,7 @@ import { examplesManifest } from '../examples/manifest.ts';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const examplesDir = path.join(rootDir, 'examples');
+const tsxCli = fileURLToPath(import.meta.resolve('tsx/cli'));
 
 function usage(): never {
   console.error('Usage: pnpm example <name> [args...]');
@@ -51,10 +52,9 @@ function runExample(target: string, args: string[]): void {
     usage();
   }
 
-  const child = spawn('tsx', [resolved, ...args], {
+  const child = spawn(process.execPath, [tsxCli, resolved, ...args], {
     cwd: rootDir,
     stdio: 'inherit',
-    shell: process.platform === 'win32',
   });
 
   child.on('exit', (code, signal) => {

--- a/src/core/dev-warnings.ts
+++ b/src/core/dev-warnings.ts
@@ -62,7 +62,11 @@ function extractStackSites(stack: string | undefined, excludedModuleUrls: readon
 
   for (const line of lines) {
     const trimmed = line.trim();
-    const match = trimmed.match(/\(?((?:file:\/\/)?[^():]+):(\d+):(\d+)\)?$/);
+    // Parse from the trailing :line:column pair so Windows drive letters,
+    // file URLs, spaces, and parentheses in paths remain intact.
+    const match =
+      trimmed.match(/\((.+):(\d+):(\d+)\)$/)
+      ?? trimmed.match(/(?:^|\s)at (.+):(\d+):(\d+)$/);
     if (!match) {
       continue;
     }

--- a/src/hooks/use-const.ts
+++ b/src/hooks/use-const.ts
@@ -3,6 +3,7 @@
  */
 
 import { getHookState, getCurrentHookIndex, setHookState } from './context.js';
+import { allowInternalSignalCreationDuringRender } from '../core/dev-warnings.js';
 
 /**
  * Lazily creates a stable value that persists across re-renders.
@@ -14,7 +15,10 @@ export function useConst<T>(factory: () => T): T {
   const { value, isNew } = getHookState<T | null>(null);
 
   if (isNew || value === null) {
-    const created = factory();
+    // A useConst factory is evaluated once and its result survives future
+    // renders. Signal-backed controllers created here are therefore stable,
+    // unlike a bare createSignal() call in component render.
+    const created = allowInternalSignalCreationDuringRender(factory);
     setHookState(getCurrentHookIndex(), created);
     return created;
   }

--- a/src/hooks/use-terminal-size.ts
+++ b/src/hooks/use-terminal-size.ts
@@ -4,6 +4,7 @@
 
 import { createSignal } from '../primitives/signal.js';
 import { getTerminalSize, onResize } from '../core/capabilities.js';
+import { useConst } from './use-const.js';
 import { useEffect } from './use-effect.js';
 
 export interface TerminalSize {
@@ -15,7 +16,7 @@ export interface TerminalSize {
  * Get reactive terminal size
  */
 export function useTerminalSize(): TerminalSize {
-  const [size, setSize] = createSignal(getTerminalSize());
+  const [size, setSize] = useConst(() => createSignal(getTerminalSize()));
 
   useEffect(() => {
     const cleanup = onResize((newSize) => {

--- a/tests/core/dev-warnings.test.ts
+++ b/tests/core/dev-warnings.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { render } from '../../src/app/render-loop.js';
-import { __resetDevWarningsForTesting } from '../../src/core/dev-warnings.js';
+import {
+  __resetDevWarningsForTesting,
+  warnIfCreateSignalDuringComponentRender,
+} from '../../src/core/dev-warnings.js';
 import { clearCommittedFrameSnapshot } from '../../src/core/frame.js';
 import { resetTerminalFocusState } from '../../src/core/terminal-focus.js';
 import { darkTheme, lightTheme, setTheme } from '../../src/core/theme.js';
@@ -138,6 +141,23 @@ describe('developer warnings', () => {
       }
 
       expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('preserves Windows drive letters when parsing callsites', () => {
+      beginRender('component');
+      try {
+        warnIfCreateSignalDuringComponentRender(
+          'Error\n    at App (C:\\consumer\\src\\app.ts:17:9)',
+          import.meta.url,
+        );
+      } finally {
+        endRender();
+      }
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toContain(
+        'C:\\consumer\\src\\app.ts:17',
+      );
     });
   });
 

--- a/tests/examples/opencode-lab.test.ts
+++ b/tests/examples/opencode-lab.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  HomeScreen,
+  SessionScreen,
+  colors,
+  type ConversationMessage,
+} from '../../examples/opencode-lab.js';
+import {
+  Text,
+  renderToString,
+  stringWidth,
+  stripAnsi,
+} from '../../src/index.js';
+
+interface Viewport {
+  width: number;
+  height: number;
+}
+
+const viewports: Viewport[] = [
+  { width: 80, height: 24 },
+  { width: 120, height: 36 },
+  { width: 160, height: 42 },
+];
+
+const messages: ConversationMessage[] = [
+  { id: 1, role: 'user', content: 'Test the responsive OpenCode layout' },
+];
+
+function composer(placeholder: string) {
+  return Text({ color: colors.muted }, placeholder);
+}
+
+function renderFrame(node: ReturnType<typeof HomeScreen>, width: number) {
+  return stripAnsi(renderToString(node, width));
+}
+
+function expectFrameWithinViewport(
+  frame: string,
+  viewport: Viewport,
+): void {
+  const lines = frame.split('\n');
+  expect(lines.length).toBeLessThanOrEqual(viewport.height);
+  expect(
+    lines.every((line) => stringWidth(line) <= viewport.width),
+  ).toBe(true);
+}
+
+describe('OpenCode lab responsive contracts', () => {
+  for (const viewport of viewports) {
+    it(`keeps the home screen inside ${viewport.width}x${viewport.height}`, () => {
+      const frame = renderFrame(
+        HomeScreen({
+          ...viewport,
+          composer: composer('Ask anything... "Fix broken tests"'),
+          agent: 'Build',
+          model: 'Big Pickle',
+        }),
+        viewport.width,
+      );
+
+      expectFrameWithinViewport(frame, viewport);
+      expect(frame).toContain('Ask anything');
+      expect(frame).toContain('ctrl+p');
+      expect(frame).toContain('Tip');
+      expect(frame).toContain('tuiuiu.js');
+    });
+
+    it(`keeps the session composer at the bottom of ${viewport.width}x${viewport.height}`, () => {
+      const frame = renderFrame(
+        SessionScreen({
+          ...viewport,
+          composer: composer('Ask a follow-up...'),
+          agent: 'Build',
+          model: 'Big Pickle',
+          sessionTitle: 'Responsive test',
+          messages,
+          thinking: true,
+          sidebarVisible: true,
+        }),
+        viewport.width,
+      );
+      const lines = frame.split('\n');
+      const composerLine = lines.findIndex((line) =>
+        line.includes('Ask a follow-up'),
+      );
+
+      expectFrameWithinViewport(frame, viewport);
+      expect(frame).toContain('Thinking');
+      expect(frame).toContain('ctrl+b');
+      expect(composerLine).toBeGreaterThanOrEqual(viewport.height - 5);
+
+      if (viewport.width >= 105) {
+        expect(frame).toContain('Context');
+        expect(frame).toContain('Getting started');
+      } else {
+        expect(frame).not.toContain('Context');
+        expect(frame).not.toContain('Getting started');
+      }
+    });
+
+    it(`centers the command overlay inside ${viewport.width}x${viewport.height}`, () => {
+      const frame = renderFrame(
+        SessionScreen({
+          ...viewport,
+          composer: composer('Ask a follow-up...'),
+          agent: 'Build',
+          model: 'Big Pickle',
+          commandOpen: true,
+        }),
+        viewport.width,
+      );
+
+      expectFrameWithinViewport(frame, viewport);
+      expect(frame).toContain('Commands');
+      expect(frame).toContain('New session');
+      expect(frame).toContain('Toggle sidebar');
+      expect(frame).toContain('Clear transcript');
+    });
+  }
+});

--- a/tests/hooks/use-const.test.ts
+++ b/tests/hooks/use-const.test.ts
@@ -1,10 +1,19 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { __resetDevWarningsForTesting } from '../../src/core/dev-warnings.js';
 import { beginRender, endRender, resetHookState } from '../../src/hooks/context.js';
 import { useConst, useState } from '../../src/hooks/index.js';
+import { createSignal } from '../../src/primitives/signal.js';
 
 describe('useConst', () => {
   beforeEach(() => {
+    __resetDevWarningsForTesting();
+    resetHookState();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    __resetDevWarningsForTesting();
     resetHookState();
   });
 
@@ -30,5 +39,23 @@ describe('useConst', () => {
     expect(factoryCalls).toBe(1);
     expect(second.value).toBe(first.value);
     expect(second.count()).toBe(3);
+  });
+
+  it('allows a stable signal-backed factory during component render', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    beginRender('component');
+    const [value, setValue] = useConst(() => createSignal(1));
+    endRender();
+
+    setValue(2);
+
+    beginRender('component');
+    const [sameValue] = useConst(() => createSignal(99));
+    endRender();
+
+    expect(sameValue).toBe(value);
+    expect(sameValue()).toBe(2);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/hooks/use-terminal-size.test.ts
+++ b/tests/hooks/use-terminal-size.test.ts
@@ -5,7 +5,20 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { useTerminalSize } from '../../src/hooks/use-terminal-size.js';
 import * as capabilities from '../../src/core/capabilities.js';
-import { resetHookState } from '../../src/hooks/context.js';
+import {
+  beginRender,
+  endRender,
+  resetHookState,
+} from '../../src/hooks/context.js';
+
+function renderTerminalSize() {
+  beginRender('component');
+  try {
+    return useTerminalSize();
+  } finally {
+    endRender();
+  }
+}
 
 describe('useTerminalSize hook', () => {
   let mockSize = { columns: 120, rows: 40 };
@@ -32,44 +45,56 @@ describe('useTerminalSize hook', () => {
 
   describe('useTerminalSize', () => {
     it('should return current terminal size', () => {
-      const size = useTerminalSize();
+      const size = renderTerminalSize();
 
       expect(size.columns).toBe(120);
       expect(size.rows).toBe(40);
     });
 
     it('should call getTerminalSize on initialization', () => {
-      useTerminalSize();
+      renderTerminalSize();
 
       expect(capabilities.getTerminalSize).toHaveBeenCalled();
     });
 
     it('should subscribe to resize events', () => {
-      useTerminalSize();
+      renderTerminalSize();
 
       expect(capabilities.onResize).toHaveBeenCalled();
     });
 
     it('should register a resize handler', () => {
-      useTerminalSize();
+      renderTerminalSize();
 
       expect(registeredHandler).not.toBeNull();
     });
 
     it('should handle different terminal sizes', () => {
       mockSize = { columns: 80, rows: 24 };
-      const size = useTerminalSize();
+      const size = renderTerminalSize();
 
       expect(size.columns).toBe(80);
       expect(size.rows).toBe(24);
     });
 
     it('should return cleanup function from onResize', () => {
-      useTerminalSize();
+      renderTerminalSize();
 
       expect(capabilities.onResize).toHaveBeenCalled();
       const onResizeCall = vi.mocked(capabilities.onResize).mock.results[0];
       expect(onResizeCall?.value).toBeInstanceOf(Function);
+    });
+
+    it('keeps resize updates across component re-renders', () => {
+      const first = renderTerminalSize();
+      expect(first).toEqual({ columns: 120, rows: 40 });
+
+      registeredHandler?.({ columns: 92, rows: 31 });
+      const resized = renderTerminalSize();
+
+      expect(resized).toEqual({ columns: 92, rows: 31 });
+      expect(capabilities.getTerminalSize).toHaveBeenCalledTimes(1);
+      expect(capabilities.onResize).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## What changed

- keep the signal used by `useTerminalSize()` stable across component renders
- allow signal-backed controllers to be initialized safely inside `useConst()`
- parse developer-warning callsites correctly when paths contain Windows drive letters, spaces, URLs, or parentheses
- add regression tests for resize persistence, warning suppression, and Windows callsites
- add `examples/opencode-lab.ts`, a no-JSX, no-CSS OpenCode-inspired responsive assistant shell
- register and document the example as `pnpm example opencode-lab`
- run examples through the `tsx` CLI without `shell: true`, removing the Node 24 `DEP0190` warning and unsafe argument concatenation on Windows
- type-check every example in the CI matrix
- add responsive renderer contracts at 80x24, 120x36, and 160x42 for the home, session, sidebar, composer, and command overlay

## Why

An external OpenCode-style consumer exposed two related problems on Windows:

1. `useTerminalSize()` created a new signal during every render, while the resize
   subscription continued updating the signal created on the first render.
2. The developer-warning stack parser truncated `C:` paths and could classify
   an internal package callsite as consumer code.

Together these could produce a false warning and make responsive layouts stop
observing the latest terminal size after a render.

The showcase then exposed a separate issue in the examples runner: Windows
used a shell solely to resolve the `tsx` executable. The runner now launches
the resolved `tsx/cli` module through `process.execPath`, preserving arguments
without shell interpolation.

## Impact

Responsive applications now keep resize state across renders, stable
signal-backed hook controllers no longer trigger a false development warning,
and diagnostics retain correct Windows source paths.

## Validation

- `pnpm test:run` — 258 files passed, 7,458 tests passed
- focused hook and warning regressions — 25 tests passed
- `pnpm lint`
- `pnpm typecheck`
- `pnpm typecheck:tests`
- `pnpm build`
- live external-consumer PTY test on Windows
- `pnpm typecheck:examples`
- `pnpm verify:contracts`
- live `pnpm example opencode-lab` test on Windows without `DEP0190`
- responsive example contracts — 9 tests passed
