### PR TITLE
ci: retire stale prerelease tag after stable releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,18 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Retire stale prerelease tag
+        if: steps.release.outputs.channel == 'latest'
+        shell: bash
+        run: |
+          if npm dist-tag ls tuiuiu.js | grep -q '^next:'; then
+            npm dist-tag rm tuiuiu.js next || {
+              echo "::warning::Stable release succeeded, but the stale npm next tag could not be removed."
+            }
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   publish-github:
     name: Publish GitHub package
     needs: [quality, audit]


### PR DESCRIPTION
## What changed

- after a successful stable npm publication, detect and remove the obsolete
  `next` dist-tag
- keep prerelease publications unchanged
- report cleanup failures as a workflow warning instead of turning an already
  completed npm publication into a partial release failure

## Why

The npm package currently exposes:

- `latest: 1.0.73`
- `next: 1.0.64-next.a2376e7`

That stale prerelease channel can mislead users and automated tooling into
treating an older build as the newest candidate. The next stable release will
now retire it using the existing `NPM_TOKEN`; no package or version is
published by this PR.

## Validation

- workflow diff checked for whitespace errors
- stable-only guard uses the existing `steps.release.outputs.channel`
- cleanup runs after `npm publish`, with non-blocking warning behavior
